### PR TITLE
Support for Base64 encoded JPEG URIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-Added support for Base64 images URIs passed as file name.
+Added support for JPEG Base64 images URIs passed as file name.
 
 Example
 ======
@@ -7,10 +7,6 @@ Example
 ```
 
 var nativePathToJpegImage = 'data:image/jpeg;base64,<data>'
-or
-var nativePathToJpegImage = 'data:image/gif;base64,<data>'
-or
-var nativePathToJpegImage = 'data:image/png;base64,<data>'
 
 window.cordova.plugins.imagesaver.saveImageToGallery(nativePathToJpegImage, onSaveImageSuccess, onSaveImageError);
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,22 @@
+Added support for Base64 images URIs passed as file name.
+
+Example
+======
+
+
+```
+
+var nativePathToJpegImage = 'data:image/jpeg;base64,<data>'
+or
+var nativePathToJpegImage = 'data:image/gif;base64,<data>'
+or
+var nativePathToJpegImage = 'data:image/png;base64,<data>'
+
+window.cordova.plugins.imagesaver.saveImageToGallery(nativePathToJpegImage, onSaveImageSuccess, onSaveImageError);
+
+```
+
+
 SaveImage
 ======
 

--- a/src/android/SaveImage.java
+++ b/src/android/SaveImage.java
@@ -21,6 +21,7 @@ import android.content.Intent;
 import android.content.pm.PackageManager;
 import android.net.Uri;
 import android.os.Environment;
+import android.util.Base64;
 import android.util.Log;
 
 /**
@@ -77,6 +78,31 @@ public class SaveImage extends CordovaPlugin {
      */
     private void performImageSave() throws JSONException {
         // create file from passed path
+
+        // BoB0: patch per supportare i file base64
+        String ext = "";
+        String dataB64 = "";
+        if (filePath.indexOf("data:image/jpeg;base64,") == 0) {
+            ext = "jpg";
+            dataB64 = filePath.substring("data:image/jpeg;base64,".length());
+        }
+
+        if (!ext.equals("")) {
+            try {
+                byte[] data = Base64.decode(dataB64, Base64.DEFAULT);
+                File outputFile = File.createTempFile("image", ext);
+                FileOutputStream stream = new FileOutputStream(outputFile);
+                stream.write(data);
+                stream.close();
+                filePath = outputFile.getAbsolutePath();
+
+            } catch (Exception e) {
+                callbackContext.error("RuntimeException occurred: " + e.getMessage());
+            }
+
+        }
+
+
         File srcFile = new File(filePath);
 
         // destination gallery folder - external storage
@@ -191,3 +217,4 @@ public class SaveImage extends CordovaPlugin {
 		}
 	}
 }
+

--- a/src/ios/SaveImage.m
+++ b/src/ios/SaveImage.m
@@ -12,9 +12,19 @@
 
         NSLog(@"Image absolute path: %@", imgAbsolutePath);
 
-	    UIImage *image = [UIImage imageWithContentsOfFile:imgAbsolutePath];
+        UIImage *image = nil;
+        if ([imgAbsolutePath hasPrefix:@"data:image/jpeg;base64,"]) {
+            image = [self decodeBase64ToImage: [imgAbsolutePath substringFromIndex:[@"data:image/jpeg;base64," length]]];
+        } else {
+            image = [UIImage imageWithContentsOfFile:imgAbsolutePath];
+        }
 	    UIImageWriteToSavedPhotosAlbum(image, self, @selector(image:didFinishSavingWithError:contextInfo:), nil);
 	}];
+}
+
+- (UIImage *)decodeBase64ToImage:(NSString *)strEncodeData {
+    NSData *data = [[NSData alloc]initWithBase64EncodedString:strEncodeData options:NSDataBase64DecodingIgnoreUnknownCharacters];
+    return [UIImage imageWithData:data];
 }
 
 - (void)dealloc {
@@ -39,3 +49,4 @@
 }
 
 @end
+


### PR DESCRIPTION
Hello,

This modified code allows to save Base64 encoded JPEG URIs to the camera roll as well as file images. 

The PR should not break compatibility with your current API.

I hope this is helpful for other developers too!