### PR TITLE
fix: Updating saving code for android to be compatible with current Android platform versions

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -21,9 +21,6 @@
 
     <!-- android -->
     <platform name="android">
-        <config-file target="AndroidManifest.xml" parent="/*">
-            <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"/>
-        </config-file>
         <config-file target="res/xml/config.xml" parent="/*">
             <feature name="SaveImage">
                 <param name="android-package" value="com.quiply.cordova.saveimage.SaveImage"/>


### PR DESCRIPTION
Hi! I tried adding this plugin to our project, but it didn't work on android. It checked a nowadays non-existing permission (`WRITE_EXTERNAL_STORAGE `) as well as using an old API which didn't scan & add the images to the android image gallery correctly.

This has only be tested on one device so far, but i'll post this here for feedback and others who might need this; also i'll give more feedback after our Q&A team has checked this on other devices as well.